### PR TITLE
Update SDK to 20.08

### DIFF
--- a/com.visualstudio.code-oss.yml
+++ b/com.visualstudio.code-oss.yml
@@ -133,6 +133,7 @@ modules:
     config-opts:
       - -Deditor_binary=/app/main/bin/code-oss
       - -Dprogram_name=code-oss
+      - -Deditor_title=Visual Studio Code Open Source
     sources:
       - type: git
         path: wrapper

--- a/com.visualstudio.code-oss.yml
+++ b/com.visualstudio.code-oss.yml
@@ -1,9 +1,9 @@
 id: com.visualstudio.code-oss
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Sdk
-runtime-version: "19.08"
+runtime-version: "20.08"
 base: org.electronjs.Electron2.BaseApp
-base-version: "19.08"
+base-version: "20.08"
 finish-args:
   - --share=ipc
   - --socket=x11

--- a/com.visualstudio.code-oss.yml
+++ b/com.visualstudio.code-oss.yml
@@ -2,8 +2,6 @@ id: com.visualstudio.code-oss
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Sdk
 runtime-version: "20.08"
-base: org.electronjs.Electron2.BaseApp
-base-version: "20.08"
 finish-args:
   - --share=ipc
   - --socket=x11


### PR DESCRIPTION
The most notable change is Python major version update (3.7 -> 3.8), meaning that modules from pypi will need to be reinstalled.