### PR TITLE
add override to pick up gtk3 theme from host

### DIFF
--- a/com.visualstudio.code-oss.yml
+++ b/com.visualstudio.code-oss.yml
@@ -14,6 +14,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.Flatpak
   - --filesystem=host
+  - --filesystem=xdg-config/gtk-3.0:ro
 command: code-oss
 rename-desktop-file: code-oss.desktop
 rename-appdata-file: code-oss.appdata.xml


### PR DESCRIPTION
This override allows VSCode use the Gtk3 theme from the host.

Without override:
![2022-06-05T12:12:44,025445016+02:00](https://user-images.githubusercontent.com/201358/172045749-7b23b8cf-4095-4ee1-8165-36393573b35a.png)

With override:
![2022-06-05T12:12:09,398820788+02:00](https://user-images.githubusercontent.com/201358/172045756-5bc33b88-6bbb-437e-a8c1-acfee3917876.png)

