### PR TITLE
Updated 3 modules, fixed ipc sockets patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/*

--- a/com.visualstudio.code-oss.yml
+++ b/com.visualstudio.code-oss.yml
@@ -71,7 +71,7 @@ modules:
         set -e
         mv product.json product.orig.json
         jq \
-        --argfile vscodium_product ../vscodium/product.json \
+        --slurpfile vscodium_product ../vscodium/product.json \
         '
           .quality="'"${VSCODE_QUALITY}"'" |
           .commit="'"$(git rev-parse HEAD)"'" |

--- a/com.visualstudio.code-oss.yml
+++ b/com.visualstudio.code-oss.yml
@@ -44,8 +44,8 @@ modules:
       - '*'
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/bc/07/830784e061fb94d67649f3e438ff63cfb902dec6d48ac75aeaaac7c7c30e/Pillow-9.4.0.tar.gz
-        sha256: a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e
+        url: https://files.pythonhosted.org/packages/80/d7/c4b258c9098b469c4a4e77b0a99b5f4fd21e359c2e486c977d231f52fc71/Pillow-10.1.0.tar.gz
+        sha256: e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38
         x-checker-data:
           type: pypi
           name: Pillow
@@ -96,8 +96,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/microsoft/vscode.git
-        tag: 1.74.3
-        commit: 97dec172d3256f8ca4bfb2143f3f76b503ca0534
+        tag: 1.84.2
+        commit: 2b35e1e6d88f1ce073683991d1eff5284a32690f
         dest: main
         x-checker-data:
           type: json
@@ -114,8 +114,8 @@ modules:
         dest: main
 
       - type: file
-        url: https://github.com/VSCodium/vscodium/raw/1.74.3.23010/product.json
-        sha256: 1dec09142eeb4116c1dc6ab70feb364bd315d22c6099eb94badcd711c9b59257
+        url: https://github.com/VSCodium/vscodium/raw/1.84.2.23314/product.json
+        sha256: 719974d90145cead8e205ab04247f38639839fffb96ce7b6c1b84525b49724c5
         dest: vscodium
         x-checker-data:
           type: json

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -131,7 +131,7 @@
     {
         "type": "file",
         "url": "https://codeload.github.com/mjbvz/markdown-it-katex/tar.gz/19f98f10f7d57f6e09049ddaced0da89b73423c5",
-        "sha256": "28d86ee8089db9e248054c4da736612752ddff2cbbe74f0bffb3ea6ce8f6ff17",
+        "sha256": "ca79342bc78df9a0cf60296e3e4977b7727292386bd2325004a46f2e08df7f81",
         "dest-filename": "19f98f10f7d57f6e09049ddaced0da89b73423c5",
         "dest": "flatpak-node/yarn-mirror"
     },

--- a/patches/ipc-sockets-paths-flatpak.patch
+++ b/patches/ipc-sockets-paths-flatpak.patch
@@ -1,15 +1,13 @@
 diff --git a/extensions/git/src/ipc/ipcServer.ts b/extensions/git/src/ipc/ipcServer.ts
-index 5cea9faf98f..0e4271162bc 100644
+index 8481aa4a35d..33c869da7dd 100644
 --- a/extensions/git/src/ipc/ipcServer.ts
 +++ b/extensions/git/src/ipc/ipcServer.ts
-@@ -16,8 +16,14 @@ function getIPCHandlePath(id: string): string {
- 		return `\\\\.\\pipe\\vscode-git-${id}-sock`;
+@@ -18,7 +18,13 @@ function getIPCHandlePath(id: string): string {
  	}
  
--	if (process.env['XDG_RUNTIME_DIR']) {
+ 	if (process.platform !== 'darwin' && process.env['XDG_RUNTIME_DIR']) {
 -		return path.join(process.env['XDG_RUNTIME_DIR'] as string, `vscode-git-${id}.sock`);
-+	const xdgRuntimeDir = process.env['XDG_RUNTIME_DIR'];
-+	if (xdgRuntimeDir) {
++		const xdgRuntimeDir = process.env['XDG_RUNTIME_DIR'];
 +		const flatpakID = process.env['FLATPAK_ID'];
 +		if (flatpakID) {
 +			return path.join(xdgRuntimeDir, 'app', flatpakID, `vscode-git-${id}.sock`);
@@ -20,10 +18,10 @@ index 5cea9faf98f..0e4271162bc 100644
  
  	return path.join(os.tmpdir(), `vscode-git-${id}.sock`);
 diff --git a/src/vs/base/parts/ipc/node/ipc.net.ts b/src/vs/base/parts/ipc/node/ipc.net.ts
-index ae2d2a60c4c..54f68436ece 100644
+index e47b6c70b23..b20cbf042c6 100644
 --- a/src/vs/base/parts/ipc/node/ipc.net.ts
 +++ b/src/vs/base/parts/ipc/node/ipc.net.ts
-@@ -477,6 +477,19 @@ const safeIpcPathLengths: { [platform: number]: number } = {
+@@ -765,6 +765,19 @@ const safeIpcPathLengths: { [platform: number]: number } = {
  	[Platform.Mac]: 103
  };
  
@@ -43,21 +41,21 @@ index ae2d2a60c4c..54f68436ece 100644
  export function createRandomIPCHandle(): string {
  	const randomSuffix = generateUuid();
  
-@@ -489,7 +502,7 @@ export function createRandomIPCHandle(): string {
- 	// XDG_RUNTIME_DIR over tmpDir
+@@ -776,7 +789,7 @@ export function createRandomIPCHandle(): string {
+ 	// Mac & Unix: Use socket file
+ 	// Unix: Prefer XDG_RUNTIME_DIR over user data path
+ 	const basePath = process.platform !== 'darwin' && XDG_RUNTIME_DIR ? XDG_RUNTIME_DIR : tmpdir();
+-	const result = join(basePath, `vscode-ipc-${randomSuffix}.sock`);
++	const result = getXdgSocketPath(`vscode-ipc-${randomSuffix}.sock`);
+ 
+ 	// Validate length
+ 	validateIPCHandleLength(result);
+@@ -803,7 +816,7 @@ export function createStaticIPCHandle(directoryPath: string, type: string, versi
+ 
  	let result: string;
- 	if (XDG_RUNTIME_DIR) {
--		result = join(XDG_RUNTIME_DIR, `vscode-ipc-${randomSuffix}.sock`);
-+		result = getXdgSocketPath(`vscode-ipc-${randomSuffix}.sock`);
+ 	if (process.platform !== 'darwin' && XDG_RUNTIME_DIR && !process.env['VSCODE_PORTABLE']) {
+-		result = join(XDG_RUNTIME_DIR, `vscode-${scopeForSocket}-${versionForSocket}-${typeForSocket}.sock`);
++		result = getXdgSocketPath(`vscode-${scopeForSocket}-${versionForSocket}-${typeForSocket}.sock`);
  	} else {
- 		result = join(tmpdir(), `vscode-ipc-${randomSuffix}.sock`);
- 	}
-@@ -513,7 +526,7 @@ export function createStaticIPCHandle(directoryPath: string, type: string, versi
- 	// unless portable
- 	let result: string;
- 	if (XDG_RUNTIME_DIR && !process.env['VSCODE_PORTABLE']) {
--		result = join(XDG_RUNTIME_DIR, `vscode-${scope.substr(0, 8)}-${version}-${type}.sock`);
-+		result = getXdgSocketPath(`vscode-${scope.substr(0, 8)}-${version}-${type}.sock`);
- 	} else {
- 		result = join(directoryPath, `${version}-${type}.sock`);
+ 		result = join(directoryPath, `${versionForSocket}-${typeForSocket}.sock`);
  	}


### PR DESCRIPTION
- vscode to v1.84.2
- pillow to 10.1.0
- fixed incorrect sha256 for markdown-it-katex (I had issues when building locally)
- (hopefully!) fixed ipc sockets patch